### PR TITLE
Fix numerical issuse when using mixed_precision

### DIFF
--- a/keras_aug/layers/__internal__/graph_xla_mode_test.py
+++ b/keras_aug/layers/__internal__/graph_xla_mode_test.py
@@ -114,7 +114,7 @@ GENERAL_TESTS = [
         "RandomCLAHE",
         layers.RandomCLAHE,
         {"value_range": (0, 255), "factor": (2, 10), "tile_grid_size": (4, 4)},
-        True,
+        False,
     ),
     (
         "RandomColorJitter",

--- a/keras_aug/layers/__internal__/mixed_precision_test.py
+++ b/keras_aug/layers/__internal__/mixed_precision_test.py
@@ -363,9 +363,10 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*GENERAL_TESTS)
     def test_run_in_mixed_precision(self, layer_cls, args, is_bbox_compatible):
+        tf.debugging.enable_check_numerics()
         keras.mixed_precision.set_global_policy("mixed_float16")
         images = tf.cast(
-            tf.random.uniform(shape=(2, 32, 32, 3)) * 255.0,
+            tf.random.uniform(shape=(2, 224, 224, 3)) * 255.0,
             dtype=tf.float64,
         )
         labels = tf.cast(
@@ -410,9 +411,10 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_run_in_mixed_precision_and_build_in_runtime(
         self, layer_cls, args, build_layer_cls, build_args
     ):
+        tf.debugging.enable_check_numerics()
         keras.mixed_precision.set_global_policy("mixed_float16")
         images = tf.cast(
-            tf.random.uniform(shape=(4, 32, 32, 3)) * 255.0,
+            tf.random.uniform(shape=(4, 224, 224, 3)) * 255.0,
             dtype=tf.float64,
         )
         labels = tf.cast(
@@ -441,3 +443,4 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def tearDownClass(cls) -> None:
         # Do not affect other tests
         keras.mixed_precision.set_global_policy("float32")
+        tf.debugging.disable_check_numerics()

--- a/keras_aug/layers/__internal__/mixed_precision_test.py
+++ b/keras_aug/layers/__internal__/mixed_precision_test.py
@@ -339,7 +339,12 @@ BUILD_IN_RUNTIME = [
 ]
 
 
-class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
+class MixedPrecisionFloat16Test(tf.test.TestCase, parameterized.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        tf.debugging.enable_check_numerics()
+        keras.mixed_precision.set_global_policy("mixed_float16")
+
     def test_all_2d_aug_layers_included(self):
         base_cls = layers.VectorizedBaseRandomLayer
         cls_spaces = [augmentation, preprocessing]
@@ -363,8 +368,6 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
 
     @parameterized.named_parameters(*GENERAL_TESTS)
     def test_run_in_mixed_precision(self, layer_cls, args, is_bbox_compatible):
-        tf.debugging.enable_check_numerics()
-        keras.mixed_precision.set_global_policy("mixed_float16")
         images = tf.cast(
             tf.random.uniform(shape=(2, 224, 224, 3)) * 255.0,
             dtype=tf.float64,
@@ -411,8 +414,6 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
     def test_run_in_mixed_precision_and_build_in_runtime(
         self, layer_cls, args, build_layer_cls, build_args
     ):
-        tf.debugging.enable_check_numerics()
-        keras.mixed_precision.set_global_policy("mixed_float16")
         images = tf.cast(
             tf.random.uniform(shape=(4, 224, 224, 3)) * 255.0,
             dtype=tf.float64,
@@ -444,3 +445,109 @@ class MixedPrecisionTest(tf.test.TestCase, parameterized.TestCase):
         # Do not affect other tests
         keras.mixed_precision.set_global_policy("float32")
         tf.debugging.disable_check_numerics()
+
+
+class MixedPrecisionBFloat16Test(tf.test.TestCase, parameterized.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        keras.mixed_precision.set_global_policy("mixed_bfloat16")
+
+    def test_all_2d_aug_layers_included(self):
+        base_cls = layers.VectorizedBaseRandomLayer
+        cls_spaces = [augmentation, preprocessing]
+        all_2d_aug_layers = []
+        for cls_space in cls_spaces:
+            all_2d_aug_layers.extend(
+                inspect.getmembers(cls_space, predicate=inspect.isclass)
+            )
+        all_2d_aug_layer_names = set(
+            item[0]
+            for item in all_2d_aug_layers
+            if issubclass(item[1], base_cls)
+        )
+
+        general_names = set(item[0] for item in GENERAL_TESTS)
+        build_names = set(item[0] for item in BUILD_IN_RUNTIME)
+        all_test_names = general_names.union(build_names)
+
+        for name in all_2d_aug_layer_names:
+            self.assertIn(name, all_test_names, msg=f"{name} not found")
+
+    @parameterized.named_parameters(*GENERAL_TESTS)
+    def test_run_in_mixed_precision(self, layer_cls, args, is_bbox_compatible):
+        images = tf.cast(
+            tf.random.uniform(shape=(2, 224, 224, 3)) * 255.0,
+            dtype=tf.float64,
+        )
+        labels = tf.cast(
+            tf.random.uniform(shape=(2, 1)) * 10.0, dtype=tf.float64
+        )
+        bounding_boxes = {
+            "boxes": tf.ragged.constant(
+                [
+                    [[10, 10, 20, 20], [100, 100, 150, 150]],
+                    [[200, 200, 400, 400]],
+                ],
+                dtype=tf.float32,
+            ),
+            "classes": tf.ragged.constant([[0, 1], [2]], dtype=tf.float32),
+        }
+        if is_bbox_compatible:
+            try:
+                layer = layer_cls(**args, bounding_box_format="xyxy")
+            except TypeError:
+                layer = layer_cls(**args)
+            inputs = {
+                IMAGES: images,
+                LABELS: labels,
+                BOUNDING_BOXES: bounding_boxes,
+            }
+        else:
+            layer = layer_cls(**args)
+            inputs = {IMAGES: images, LABELS: labels}
+
+        outputs = layer(inputs)
+
+        if is_bbox_compatible:
+            self.assertDTypeEqual(outputs[IMAGES], tf.bfloat16)
+            dense_bounding_boxes = bounding_box.to_dense(
+                outputs[BOUNDING_BOXES]
+            )
+            self.assertDTypeEqual(dense_bounding_boxes["boxes"], tf.bfloat16)
+        else:
+            self.assertDTypeEqual(outputs[IMAGES], tf.bfloat16)
+
+    @parameterized.named_parameters(*BUILD_IN_RUNTIME)
+    def test_run_in_mixed_precision_and_build_in_runtime(
+        self, layer_cls, args, build_layer_cls, build_args
+    ):
+        images = tf.cast(
+            tf.random.uniform(shape=(4, 224, 224, 3)) * 255.0,
+            dtype=tf.float64,
+        )
+        labels = tf.cast(
+            tf.random.uniform(shape=(4, 1)) * 10.0, dtype=tf.float64
+        )
+        name = args["name"]
+        value = args["value"]
+        other_args = args["args"]
+        if value == "single":
+            build_layers = build_layer_cls(**build_args)
+        elif value == "multiple":
+            build_layers = [
+                build_layer_cls(**build_args),
+                build_layer_cls(**build_args),
+            ]
+        else:
+            raise NotImplementedError()
+        args = {name: build_layers, **other_args}
+        layer = layer_cls(**args)
+
+        outputs = layer({IMAGES: images, LABELS: labels})
+
+        self.assertDTypeEqual(outputs[IMAGES], tf.bfloat16)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Do not affect other tests
+        keras.mixed_precision.set_global_policy("float32")

--- a/keras_aug/layers/__internal__/output_common_test.py
+++ b/keras_aug/layers/__internal__/output_common_test.py
@@ -358,26 +358,10 @@ NO_PRESERVED_SHAPE = [
     layers.Resize,
 ]
 
-NO_BFLOAT16 = [
-    # tf.raw_ops.ImageProjectiveTransformV3 is not supported with bfloat16
-    layers.AugMix,
-    layers.RandAugment,
-    layers.TrivialAugmentWide,
-    layers.RandomAffine,
-    layers.RandomCrop,
-    layers.RandomCropAndResize,
-    layers.RandomRotate,
-    layers.MixUp,  # tf.random.stateless_gamma
-]
-
 NO_UINT8 = [
     layers.AugMix,  # alpha
     layers.RandAugment,  # stateless_random_uniform
     layers.TrivialAugmentWide,  # stateless_random_uniform
-    layers.RandomAffine,  # stateless_random_uniform
-    layers.RandomCrop,  # stateless_random_uniform
-    layers.RandomRotate,  # stateless_random_uniform
-    layers.RandomZoomAndCrop,  # stateless_random_uniform
     layers.RandomSharpness,  # stateless_random_uniform
     layers.RandomSolarize,  # stateless_random_uniform
     layers.CutMix,  # tf.convert_to_tensor
@@ -533,14 +517,9 @@ class OutputCommonTest(tf.test.TestCase, parameterized.TestCase):
         self.assertDTypeEqual(results[IMAGES], tf.float16)
 
         # bfloat16
-        if layer_cls not in NO_BFLOAT16:
-            layer = layer_cls(**copied_args, dtype=tf.bfloat16)
-            results = layer(inputs)
-            self.assertDTypeEqual(results[IMAGES], tf.bfloat16)
-        else:
-            with self.assertRaises(tf.errors.InvalidArgumentError):
-                layer = layer_cls(**copied_args, dtype=tf.bfloat16)
-                layer(inputs)
+        layer = layer_cls(**copied_args, dtype=tf.bfloat16)
+        results = layer(inputs)
+        self.assertDTypeEqual(results[IMAGES], tf.bfloat16)
 
         # uint8
         if layer_cls not in NO_UINT8:

--- a/keras_aug/layers/__internal__/output_common_test.py
+++ b/keras_aug/layers/__internal__/output_common_test.py
@@ -367,7 +367,6 @@ NO_BFLOAT16 = [
     layers.RandomCrop,
     layers.RandomCropAndResize,
     layers.RandomRotate,
-    layers.CutMix,  # tf.random.stateless_gamma
     layers.MixUp,  # tf.random.stateless_gamma
 ]
 
@@ -383,10 +382,7 @@ NO_UINT8 = [
     layers.RandomSolarize,  # stateless_random_uniform
     layers.CutMix,  # tf.convert_to_tensor
     layers.MixUp,  # tf.convert_to_tensor
-    layers.Mosaic,  # stateless_random_uniform
     layers.RandomCutout,  # tf.where with -1 (invalid bbox)
-    layers.RandomErase,  # stateless_random_uniform
-    layers.RandomGridMask,  # tf.sqrt
     layers.RandomHSV,  # stateless_random_uniform
     layers.RandomChannelShift,  # stateless_random_uniform
     layers.RandomColorJitter,  # stateless_random_uniform

--- a/keras_aug/layers/augmentation/geometry/random_crop_and_resize.py
+++ b/keras_aug/layers/augmentation/geometry/random_crop_and_resize.py
@@ -144,6 +144,10 @@ class RandomCropAndResize(VectorizedBaseRandomLayer):
         batch_size = tf.shape(images)[0]
         boxes = transformations
         indices = tf.range(batch_size)
+
+        # tf.image.crop_and_resize not support bfloat16
+        if images.dtype == tf.bfloat16:
+            images = tf.cast(images, dtype=tf.float32)
         images = tf.image.crop_and_resize(
             images,  # image shape: [B, H, W, C]
             boxes,  # boxes: (B, 4) in this case; represents area
@@ -242,6 +246,10 @@ class RandomCropAndResize(VectorizedBaseRandomLayer):
         batch_size = tf.shape(segmentation_masks)[0]
         boxes = transformations
         indices = tf.range(batch_size)
+
+        # tf.raw_ops.ImageProjectiveTransformV3 not support bfloat16
+        if segmentation_masks.dtype == tf.bfloat16:
+            segmentation_masks = tf.cast(segmentation_masks, dtype=tf.float32)
         segmentation_masks = tf.image.crop_and_resize(
             segmentation_masks,  # image shape: [B, H, W, C]
             boxes,  # boxes: (B, 4) in this case; represents area

--- a/keras_aug/layers/augmentation/intensity/random_clahe.py
+++ b/keras_aug/layers/augmentation/intensity/random_clahe.py
@@ -63,13 +63,14 @@ class RandomCLAHE(VectorizedBaseRandomLayer):
         images = preprocessing_utils.transform_value_range(
             images, self.value_range, (0, 255), dtype=self.compute_dtype
         )
-        inputs_for_RandomCLAHE_single_image = {
+        inputs_for_clahe_single_image = {
             "images": images,
             "clip_limits": transformations,
         }
-        images = tf.vectorized_map(
-            self.RandomCLAHE_single_image,
-            inputs_for_RandomCLAHE_single_image,
+        images = tf.map_fn(
+            self.clahe_single_image,
+            inputs_for_clahe_single_image,
+            fn_output_signature=self.compute_dtype,
         )
         images = preprocessing_utils.transform_value_range(
             images, (0, 255), self.value_range, dtype=self.compute_dtype
@@ -104,7 +105,7 @@ class RandomCLAHE(VectorizedBaseRandomLayer):
         clipped_hists = clipped_hists + tf.math.truediv(clipped_px_count, 256)
         return clipped_hists
 
-    def RandomCLAHE_single_image(self, inputs):
+    def clahe_single_image(self, inputs):
         image = inputs.get("images", None)
         clip_limit = inputs.get("clip_limits", None)
 

--- a/keras_aug/layers/augmentation/intensity/random_clahe_test.py
+++ b/keras_aug/layers/augmentation/intensity/random_clahe_test.py
@@ -79,7 +79,7 @@ class RandomCLAHETest(tf.test.TestCase):
 
         self.assertNotAllClose(image, output)
 
-    def test_RandomCLAHE_output(self):
+    def test_random_clahe_output(self):
         image_shape = (4, 8, 8, 3)
         image = tf.random.uniform(shape=image_shape) * 255.0
         image = tf.cast(image, dtype=tf.uint8)

--- a/keras_aug/layers/augmentation/intensity/random_hsv.py
+++ b/keras_aug/layers/augmentation/intensity/random_hsv.py
@@ -154,14 +154,16 @@ class RandomHSV(VectorizedBaseRandomLayer):
         return keypoints
 
     def adjust_hue(self, images, transformations):
-        images = tf.image.rgb_to_hsv(images)
-        hue_factors = transformations["hue_factors"]
+        # cast to float32 to avoid numerical issue
+        images = tf.image.rgb_to_hsv(tf.cast(images, dtype=tf.float32))
+        hue_factors = tf.cast(transformations["hue_factors"], dtype=tf.float32)
         h_channels = tf.math.floormod(images[..., 0:1] + hue_factors, 1.0)
         images = tf.concat(
             [h_channels, images[..., 1:2], images[..., 2:3]], axis=-1
         )
         images = tf.image.hsv_to_rgb(images)
-        return images
+        images = tf.clip_by_value(images, 0, 255)
+        return tf.cast(images, dtype=self.compute_dtype)
 
     def adjust_saturation(self, images, transformations):
         saturation_factors = transformations["saturation_factors"]

--- a/keras_aug/layers/augmentation/mix/cut_mix.py
+++ b/keras_aug/layers/augmentation/mix/cut_mix.py
@@ -49,8 +49,8 @@ class CutMix(VectorizedBaseRandomLayer):
     def get_random_transformation_batch(
         self, batch_size, images=None, **kwargs
     ):
-        height = tf.cast(tf.shape(images)[H_AXIS], dtype=self.compute_dtype)
-        width = tf.cast(tf.shape(images)[W_AXIS], dtype=self.compute_dtype)
+        height = tf.cast(tf.shape(images)[H_AXIS], dtype=tf.float32)
+        width = tf.cast(tf.shape(images)[W_AXIS], dtype=tf.float32)
         permutation_order = self._random_generator.random_uniform(
             (batch_size,),
             minval=0,
@@ -63,20 +63,14 @@ class CutMix(VectorizedBaseRandomLayer):
             seed_beta=self._random_generator.make_seed_for_stateless_op(),
             alpha=self.alpha,
             beta=self.alpha,
-            dtype=self.compute_dtype,
+            dtype=tf.float32,
         )
         ratios = tf.math.sqrt(1.0 - lambda_samples)
-        height = tf.cast(tf.shape(images)[H_AXIS], dtype=self.compute_dtype)
-        width = tf.cast(tf.shape(images)[W_AXIS], dtype=self.compute_dtype)
         cut_heights = tf.cast(ratios * height, dtype=tf.int32)
         cut_widths = tf.cast(ratios * width, dtype=tf.int32)
-        center_xs = self._random_generator.random_uniform(
-            shape=(batch_size,), dtype=self.compute_dtype
-        )
+        center_xs = self._random_generator.random_uniform(shape=(batch_size,))
         center_xs = tf.cast(center_xs * width, dtype=tf.int32)
-        center_ys = self._random_generator.random_uniform(
-            shape=(batch_size,), dtype=self.compute_dtype
-        )
+        center_ys = self._random_generator.random_uniform(shape=(batch_size,))
         center_ys = tf.cast(center_ys * height, dtype=tf.int32)
         return {
             "permutation_order": permutation_order,

--- a/keras_aug/layers/augmentation/regularization/random_erase.py
+++ b/keras_aug/layers/augmentation/regularization/random_erase.py
@@ -79,19 +79,17 @@ class RandomErase(VectorizedBaseRandomLayer):
         self, batch_size, images=None, **kwargs
     ):
         heights, widths = augmentation_utils.get_images_shape(
-            images, dtype=self.compute_dtype
+            images, dtype=tf.float32
         )
         areas = heights * widths
 
         is_success = False
         for _ in range(self.max_attemp):
             if not is_success:
-                erasing_areas = self.area_factor(
-                    shape=(batch_size, 1), dtype=self.compute_dtype
-                )
+                erasing_areas = self.area_factor(shape=(batch_size, 1))
                 erasing_areas = erasing_areas * areas
                 erasing_aspect_ratios = self.aspect_ratio_factor(
-                    shape=(batch_size, 1), dtype=self.compute_dtype
+                    shape=(batch_size, 1)
                 )
                 erasing_heights = tf.round(
                     tf.sqrt(erasing_areas * erasing_aspect_ratios)
@@ -105,10 +103,10 @@ class RandomErase(VectorizedBaseRandomLayer):
                     is_success = True
 
         center_xs = self._random_generator.random_uniform(
-            shape=(batch_size, 1), minval=0, maxval=1, dtype=self.compute_dtype
+            shape=(batch_size, 1), minval=0, maxval=1, dtype=tf.float32
         )
         center_ys = self._random_generator.random_uniform(
-            shape=(batch_size, 1), minval=0, maxval=1, dtype=self.compute_dtype
+            shape=(batch_size, 1), minval=0, maxval=1, dtype=tf.float32
         )
         center_xs = tf.round(center_xs * (widths - erasing_widths))
         center_xs = tf.cast(center_xs + erasing_widths / 2, dtype=tf.int32)


### PR DESCRIPTION
This PR enables the support of:
- `keras.mixed_precision.set_global_policy("mixed_float16")`
- `keras.mixed_precision.set_global_policy("mixed_bfloat16")`